### PR TITLE
Remove useless param from create-token cmd

### DIFF
--- a/x/asset/client/cli/tx_create_token.go
+++ b/x/asset/client/cli/tx_create_token.go
@@ -16,9 +16,9 @@ var _ = strconv.Itoa(0)
 
 func CmdCreateToken() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "create-token [name] [symbol] [total] [decimals] [authorization-required]",
+		Use:   "create-token [name] [symbol] [total] [authorization-required]",
 		Short: "Broadcast message CreateToken",
-		Args:  cobra.ExactArgs(5),
+		Args:  cobra.ExactArgs(4),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			argName := args[0]
 			argSymbol := args[1]

--- a/x/asset/client/cli/tx_msg_create_token.go
+++ b/x/asset/client/cli/tx_msg_create_token.go
@@ -18,7 +18,7 @@ func CmdMsgCreateToken() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "msg-create-token [name] [symbol] [total] [authorization-required]",
 		Short: "Broadcast message MsgCreateToken",
-		Args:  cobra.ExactArgs(5),
+		Args:  cobra.ExactArgs(4),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			argName := args[0]
 			argSymbol := args[1]


### PR DESCRIPTION
Remove _decimals_ parameter and reduce number of parameters to 4 